### PR TITLE
Add lightweight HTTP API interface and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+resonance.db
+test_resonance.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Resonance+ MVP Blueprint
+
+This repository contains design artifacts and an in-progress service implementation for **Resonance+**, a consent-first, chemistry-focused dating platform. The codebase now includes a pure Python domain service that captures consent decisions, ingests conversation signals (with explicit permission), and produces chemistry-aligned match suggestions backed by SQLite persistence.
+
+## Contents
+
+- `docs/product-spec.md` — Founder-grade MVP product specification covering product goals, user journeys, system architecture, data models, AI pipelines, safety, fairness, and KPIs.
+- `docs/privacy-consent.md` — Consent, privacy, and data-handling framework.
+- `docs/agent-runbook.md` — Suggested prompts and sequencing for orchestrating auto-coder agents to implement the MVP.
+
+## Getting Started
+
+### Running the HTTP API
+
+The repository ships with a lightweight HTTP server built with the Python standard library. Start it via:
+
+```bash
+python -m resonance.api --host 127.0.0.1 --port 8000 --database resonance.db
+```
+
+Endpoints follow a REST-style pattern for user onboarding, consent management, conversation ingestion, match suggestions, and feedback. See `tests/test_api.py` for representative request payloads and expected responses.
+
+### Using the domain service
+
+The prototype targets Python 3.11+ and has no third-party runtime dependencies. You can explore the core functionality from a Python REPL:
+
+```python
+>>> from datetime import datetime
+>>> from resonance.service import ResonanceService, ConversationMessage
+>>> from resonance.models import ConsentScope
+>>> service = ResonanceService()
+>>> user = service.register_user("you@example.com", "You", consent_flags={ConsentScope.IN_APP_ANALYSIS: True})
+>>> _ = service.ingest_conversation(user.id, [
+...     ConversationMessage(author="self", text="What inspires you?", timestamp=datetime.utcnow()),
+...     ConversationMessage(author="partner", text="Collaborative futures!", timestamp=datetime.utcnow()),
+... ])
+>>> service.suggest_matches(user.id)
+[]
+```
+
+The storage layer defaults to an in-memory SQLite database. Provide a file path to persist data between sessions: `ResonanceService(Storage("resonance.db"))`.
+
+### Tests
+
+Run the automated test suite with:
+
+```bash
+pytest
+```
+
+### Next steps
+
+Review the product spec first, then follow the agent runbook to extend the implementation using your preferred autonomous coding agent. Ensure all development adheres to the consent and privacy commitments documented in `docs/privacy-consent.md`.

--- a/docs/agent-runbook.md
+++ b/docs/agent-runbook.md
@@ -1,0 +1,71 @@
+# Resonance+ Agent-Oriented Build Runbook
+
+This runbook outlines a recommended sequence of prompts and tasks for orchestrating autonomous coding agents (e.g., GPT-5 Agent Mode, Devin, Cursor) to implement the Resonance+ MVP as described in `product-spec.md`.
+
+## 1. Preparation
+- Set up a GitHub repository with CI/CD integrations (GitHub Actions).
+- Provision Supabase project (Auth, Postgres, Storage) and store service keys securely.
+- Ensure agents have access to the specification documents and environment credentials.
+
+## 2. Prompt Sequence Overview
+Each prompt should be executed as a separate pull request/task, with human review between steps.
+
+1. **Repo Initialization & Standards**
+   - Prompt: _"Create a mono-repo with directories apps/, services/, infra/, ops/, docs/. Configure linting (Black/Ruff for Python, ESLint/Prettier for JS), formatting hooks, MIT license, README, and GitHub Actions for lint/test."_
+   - Acceptance: All pipelines green, documentation generated.
+
+2. **Database Schema & Consent Tables**
+   - Prompt: _"Using Supabase, define schemas for users, profiles, consents, consent_audit, social_links, messages, conversations, convo_metrics, embeddings, matches, flow_signals, reports, moderation_actions. Add RLS policies and SQL migrations."_
+   - Acceptance: Schema matches spec, policies enforce per-user access, migrations executable.
+
+3. **Consent Onboarding UI**
+   - Prompt: _"Implement onboarding flow with consent toggles (chat analysis, voice analysis, social scrape), explanations, and audit logging. Include consent management dashboard."_
+   - Acceptance: UI matches Figma/wireframes, API endpoints created, audit entries verified in DB.
+
+4. **Feature Extraction Service**
+   - Prompt: _"Create FastAPI service with endpoints /extract/text and /extract/social. Implement text metrics (question ratio, sentiment, curiosity), output embeddings via Sentence Transformers, and generate unit tests with synthetic data."_
+   - Acceptance: Tests passing, service dockerized, API documented.
+
+5. **Matching Engine**
+   - Prompt: _"Build matching microservice that aggregates user embeddings, computes candidate matches with FAISS/pgvector, applies reranker with fairness constraints and diversity penalty. Provide nightly batch job script."_
+   - Acceptance: Synthetic evaluation demonstrating mutual score ranking, fairness constraint scaffolding present.
+
+6. **Chat Experience & Flow Meter**
+   - Prompt: _"Develop chat UI with E2EE, challenge card insertion, and inline flow meter. Wire backend endpoints for storing encrypted messages and flow signals."_
+   - Acceptance: Secure storage verified, flow taps recorded, tests covering encryption pipeline.
+
+7. **Moderation & Safety Tools**
+   - Prompt: _"Implement toxicity detection (Perspective/open-source), spam throttling, block/report endpoints, and moderation dashboard with audit logging."_
+   - Acceptance: Safety incidents logged, admin dashboard protected by role-based auth.
+
+8. **Explainability & Settings**
+   - Prompt: _"Add 'Why this match' explainer with adjustable weights, Fresh Start mode, data export/delete flows, and consent history timeline."_
+   - Acceptance: Explanations traceable to metrics, export produces JSON bundle, delete flow wipes embeddings.
+
+9. **Analytics & Bias Monitoring**
+   - Prompt: _"Set up analytics job to compute weekly KPIs (flow rate, satisfaction, safety). Implement fairness report comparing match scores across cohorts with DP noise."_
+   - Acceptance: Dashboard or reports generated, DP parameters documented.
+
+10. **Deployment Automation**
+    - Prompt: _"Configure staging deployment (Supabase + Cloud Run/Render). Add end-to-end tests (Playwright) for onboarding→match→chat→report. Deploy on green builds."_
+    - Acceptance: CI/CD pipeline deploys successfully; tests cover happy path and consent revocation.
+
+## 3. Human Oversight Checklist
+- Review each PR for adherence to consent & privacy requirements.
+- Verify that raw social data is not persisted beyond processing.
+- Confirm fairness constraints and bias audits are implemented.
+- Conduct manual security assessment before pilot (auth, RLS, key storage).
+
+## 4. Pilot Readiness Criteria
+- All critical bugs closed.
+- Safety team trained on moderation dashboard and escalation playbook.
+- Transparency materials published (privacy policy, model cards, algorithmic explainers).
+- Pilot cohort onboarded with clear communication on data use and exit options.
+
+## 5. Future Agent Tasks (Post-MVP)
+- Integrate federated learning for on-device feature extraction.
+- Expand provider support for social scraping with enhanced consent flows.
+- Launch community event tooling (Resonance Salons).
+- Build recommendation engine for collaborative prompts/games.
+
+Use this runbook as a living document—update prompts and acceptance criteria as the architecture evolves.

--- a/docs/privacy-consent.md
+++ b/docs/privacy-consent.md
@@ -1,0 +1,64 @@
+# Resonance+ Consent, Privacy, and Data Handling Framework
+
+## 1. Principles
+- **Explicit consent** for every data scope; nothing is scraped or analyzed without opt-in.
+- **Revocability**: Users can pause or revoke consent at any time; revocation triggers deletion workflows for derived data.
+- **Minimization**: Store only derived embeddings and summaries whenever possible. Raw message content remains on device or encrypted.
+- **Transparency**: Explain how data is used, provide model cards, and expose "Why this match" rationale.
+- **Safety-first overrides**: Break-glass access allowed only for active safety investigations with audit logging.
+
+## 2. Consent Scopes
+
+| Scope | Required? | Data Types | Purpose | Storage |
+|-------|-----------|-----------|---------|---------|
+| `chat_analysis` | Yes | In-app text messages, flow taps | Chemistry modeling, safety monitoring | Encrypted raw messages (short retention), derived metrics + embeddings |
+| `voice_analysis` | Optional | Voice notes (in-app) | Prosody features for chemistry vector | Transient processing, derived prosody metrics |
+| `social_scrape` | Optional | Posts/comments from linked accounts | Values & style enrichment | Summaries + embeddings only; raw content discarded post-processing |
+
+## 3. User Controls
+- Consent toggles in onboarding and Settings → Privacy.
+- Each toggle displays benefits, data used, and ability to pause or delete history.
+- "Download my data" exports embeddings, summaries, and metadata in JSON.
+- "Delete my account" wipes profile, matches, conversations, and vectors (with 30-day safety hold for active investigations).
+
+## 4. Data Flows
+1. **In-App Messages**
+   - Messages sent → encrypted at rest.
+   - Feature extraction service computes conversation metrics in real time.
+   - After 90 days, raw messages are pruned unless conversation is reported; metrics retained.
+2. **Voice Notes**
+   - Uploaded voice stored encrypted.
+   - On consent, speech-to-text + prosody metrics computed; raw waveform deleted after 30 days.
+3. **Social Media**
+   - User authorizes via OAuth/token.
+   - Limited fetch (last 90 days, 500 items max) → summarizer extracts tone/values → raw items purged.
+   - User reviews summary before it is incorporated into embeddings.
+4. **Safety Reports**
+   - Copy of relevant conversation retained for investigation; access logged.
+   - Upon resolution, data is anonymized or deleted per policy.
+
+## 5. Security Posture
+- End-to-end encryption for chats; key escrow only for user-initiated safety reports.
+- Row-level security in database ensuring users access only their own records.
+- Secrets stored in managed vault (e.g., Supabase secrets, HashiCorp Vault).
+- Regular penetration testing and red-team drills focusing on data exfiltration scenarios.
+
+## 6. Differential Privacy & Analytics
+- Aggregate analytics apply calibrated DP noise to protect individual contributions.
+- No third-party trackers; analytics limited to first-party privacy-preserving tools.
+- Model updates use federated learning roadmap; interim approach uses anonymized batches with DP clipping.
+
+## 7. Compliance
+- GDPR and CCPA ready: data access, correction, deletion, portability supported.
+- Age gating (18+) with KYC/ID verification provider.
+- Incident response playbook aligned with SOC 2 and ISO 27001 best practices.
+
+## 8. Audit & Governance
+- Quarterly privacy review covering data flows, retention, and consent logs.
+- Ethics board reviews algorithmic fairness reports and approves major model changes.
+- Public transparency report summarizing safety incidents, data requests, and algorithm updates.
+
+## 9. Open Questions
+- Determine regional data residency requirements.
+- Evaluate feasibility of on-device encryption keys controlled solely by user.
+- Plan for community moderation involvement while preserving privacy guarantees.

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -1,0 +1,266 @@
+# Resonance+ MVP Product Specification
+
+_Last updated: 2025-02-16_
+
+## 1. Vision & Value Proposition
+
+Resonance+ is a consent-first dating platform that optimizes for conversational chemistry instead of swipe velocity. By combining in-app conversational signals with optional, user-authorized social media summaries, the system creates adaptive "chemistry vectors" that drive slow, high-quality match curation. The goal is to help rare, systems-oriented thinkers find depth, resonance, and safety in dating.
+
+### Primary Value Pillars
+- **Chemistry over looks**: Face-last experience emphasizing prompts, voice notes, and conversation depth before photos.
+- **Consent & transparency**: Explicit, revocable data scopes at onboarding and throughout the product. Users always understand how signals are used.
+- **Adaptive matching**: Multi-objective AI that optimizes for mutual flow, diversity, and fairness across cohorts.
+- **Safety-first operations**: Embedded moderation tooling, toxicity detection, and human review queues.
+
+## 2. Target Users & Use Cases
+
+### Personas
+1. **Systems Thinker** – enjoys philosophy, future scenarios, and long-form discussions; frustrated by superficial apps.
+2. **Slow Connector** – prefers deeper, fewer conversations; values safety and intentionality.
+3. **Curious Builder** – open to co-creating micro-utopias or speculative scenarios; seeks playful intellect.
+
+### Core Jobs-to-Be-Done
+- Discover people who match your conversational energy and curiosity.
+- Maintain control over how your data is used and revoke access at any time.
+- Receive a manageable cadence (3–5 per week) of high-quality introductions.
+- Understand why a match was suggested and adjust preferences without starting over.
+- Feel safe reporting, blocking, or pausing interactions when necessary.
+
+## 3. Success Metrics (MVP Focus)
+- **Conversation Flow Rate**: ≥ 10 back-and-forth messages in at least 60% of active matches.
+- **Flow Sentiment**: ≥ 40% of weekly users tap "Great flow" at least once.
+- **Conversion to Date**: ≥ 25% of active matches lead to an offline/virtual date with ≥ 4/5 satisfaction.
+- **Safety Health**: < 2 confirmed safety incidents per 1k conversations; 100% of reports triaged within 24h.
+- **Fairness Parity**: Chemistry score distribution variance ≤ 10% across gender and ethnicity cohorts.
+
+## 4. Product Scope (MVP)
+
+### 4.1 Platforms
+- Mobile-responsive web app (React/Next.js or FlutterFlow export) for MVP.
+- Native mobile wrappers optional post-MVP.
+
+### 4.2 Key Features
+1. **Account Creation & Consent Onboarding**
+   - Email/phone-based signup with age verification (18+).
+   - Consent toggles for data scopes:
+     - In-app message analysis (required for matching).
+     - Voice note analysis (optional).
+     - Social media summarization (optional per linked account).
+   - Audit trail and granular revoke controls accessible from settings.
+
+2. **Profile Setup**
+   - Long-form prompts (e.g., "Design a law for a kinder internet").
+   - Optional 2-minute voice note introduction.
+   - Preferences: genders, distance radius, desired pace (number of matches/week).
+   - Face-last photo handling: option to blur or delay photo reveal.
+
+3. **Match Delivery**
+   - Weekly batch of 3–5 matches curated by matching service.
+   - "Why we matched you" explainer with editable weighting sliders (e.g., Humor, Depth, Tempo).
+   - Optional challenge cards to initiate conversation.
+
+4. **Conversation Experience**
+   - Secure chat with E2EE; optional voice notes.
+   - Inline "flow meter" (Great / Okay / Flat) accessible every 5 messages.
+   - Ability to pause, hide, or delete a conversation; honoring consent preferences.
+
+5. **Social Media Integration (Optional)**
+   - OAuth or token-based link for Twitter/X, Instagram, or Reddit.
+   - Agent fetches recent posts/comments (last 90 days, capped volume), summarizes tone/values.
+   - Display summary to user with option to edit or delete before use.
+
+6. **Safety & Moderation**
+   - Block/report controls in every conversation.
+   - Automated toxicity classifier (text + voice) with throttling.
+   - Human moderation dashboard (internal only) with break-glass access logging.
+
+7. **Settings & Data Control**
+   - Consent dashboard with history and toggles.
+   - Data export (JSON summaries) and delete account (with verified wipe) flows.
+   - Fresh Start mode: reset embeddings while retaining account.
+
+### 4.3 Out of Scope (MVP)
+- Video chat, live events, algorithmic photo ranking, ad placements, third-party data resale.
+
+## 5. System Architecture Overview
+
+```
+apps/
+  web/ (Next.js or Flutter app)
+services/
+  api-gateway/ (FastAPI/Node) – auth, routing, rate limits
+  features/ (Python) – text & social feature extraction
+  matching/ (Python) – embeddings, reranker, fairness constraints
+  moderation/ (Python/Node) – toxicity, abuse handling
+infra/
+  db/ (Supabase Postgres schema + policies)
+  storage/ (User uploads, encrypted)
+  queue/ (Task queue for async jobs)
+ops/
+  ci/ (GitHub Actions)
+  monitoring/ (Logging, alerts)
+```
+
+- **Client** communicates with `api-gateway` via HTTPS.
+- `api-gateway` enforces auth (Supabase auth tokens) and forwards to internal services.
+- Feature extraction runs synchronously for chat (low-latency) and asynchronously for social media ingestion.
+- Matching service operates nightly to recompute candidate sets and on-demand for refresh requests.
+- Moderation service listens to event bus for new messages and flags.
+- Data warehouse (optional) receives anonymized aggregates for analytics.
+
+## 6. Data Model (Supabase / Postgres)
+
+### 6.1 Core Tables
+
+| Table | Description | Key Fields |
+|-------|-------------|------------|
+| `users` | Auth-linked accounts | `id`, `email`, `phone`, `dob`, `created_at` |
+| `profiles` | Public profile data | `user_id`, `display_name`, `bio`, `voice_note_url`, `photo_url`, `preferences` (JSONB) |
+| `consents` | Per-scope consent flags | `user_id`, `scope` (`chat_analysis`, `voice_analysis`, `social_scrape`), `status`, `granted_at`, `revoked_at` |
+| `consent_audit` | History of changes | `id`, `user_id`, `scope`, `action`, `timestamp`, `actor` |
+| `social_links` | OAuth tokens/meta | `user_id`, `provider`, `account_handle`, `status`, `last_synced_at` |
+| `messages` | Encrypted conversation payloads | `id`, `conversation_id`, `sender_id`, `ciphertext`, `sent_at`, `flow_feedback` |
+| `conversations` | Match-level threads | `id`, `user_a`, `user_b`, `match_id`, `status`, `created_at`, `closed_at` |
+| `convo_metrics` | Derived summaries | `conversation_id`, `metric_type`, `value`, `window_start`, `window_end` |
+| `embeddings` | User-level vectors | `user_id`, `vector_type` (`chemistry`, `social_values`), `vector`, `updated_at` |
+| `matches` | Match records | `id`, `user_a`, `user_b`, `status`, `score`, `created_at`, `expires_at` |
+| `flow_signals` | Explicit feedback | `id`, `conversation_id`, `user_id`, `signal` (`great`, `ok`, `flat`), `message_index`, `timestamp` |
+| `reports` | Safety reports | `id`, `reporter_id`, `reported_id`, `conversation_id`, `reason`, `status`, `triaged_at` |
+| `moderation_actions` | Enforcement log | `id`, `user_id`, `action`, `reason`, `performed_by`, `timestamp` |
+
+### 6.2 Access Policies
+- Row-Level Security: Users can access only their own profiles, consents, social links, and conversations.
+- Service-role keys for internal services (matching, moderation) with narrow scopes.
+- All consent toggles must be stored transactionally with audit entries.
+
+## 7. Consent & Privacy Requirements (Summary)
+- **Explicit consent** for each data scope during onboarding; default is opt-out for non-essential scopes.
+- **Revoke anytime**: toggles immediately stop future collection and trigger deletion workflows for derived data (except safety logs).
+- **Data minimization**: store only embeddings and short summaries; raw social posts/messages remain client-side unless report triggers safety review.
+- **Transparency**: Provide human-readable explanations of features extracted and how they influence matches.
+- **Differential Privacy**: Apply DP noise when aggregating metrics for analytics or model updates.
+
+(Full policy in `docs/privacy-consent.md`.)
+
+## 8. AI & Matching Pipeline
+
+### 8.1 Inputs
+- **In-app chat**: sequences of messages (text, emojis, optional voice transcripts) with metadata.
+- **Flow feedback**: user taps, conversation continuation length.
+- **Profile prompts/voice**: onboarding responses.
+- **Social summaries** (optional): hashed embeddings of linked accounts.
+
+### 8.2 Feature Extraction
+1. **Text Metrics**
+   - Question ratio, turn-taking balance, latency distribution.
+   - Semantic depth (embedding variance, abstraction level).
+   - Sentiment arcs, empathy markers, conflict resolution phrases.
+   - Humor/play signals (callbacks, irony, playful negation).
+2. **Voice (optional)**
+   - Prosody: tempo, energy, warmth, variability.
+   - Confidence vs hesitancy (spectral features).
+3. **Social Summaries (optional)**
+   - Dominant topics (LDA or transformer-based topic modeling).
+   - Value orientation (community-driven vs individualistic, future vs present).
+   - Interaction style (supportive, debate-heavy, observational).
+
+All features are normalized and concatenated into a **Chemistry Vector** (dimension 64–128). Sensitive attributes are excluded.
+
+### 8.3 Matching Engine
+- **Embedding Model**: Bi-encoder (e.g., Sentence Transformers) fine-tuned with contrastive loss on high-flow conversation pairs.
+- **Candidate Generation**: FAISS or pgvector for nearest-neighbor retrieval.
+- **Reranker**: Multi-objective optimization combining predicted mutual chemistry, diversity penalty, fairness constraints, safety risk score, and freshness (avoid repeat matches).
+- **Exploration vs Exploitation**: Contextual bandit to inject serendipitous matches while respecting constraints.
+- **Scheduling**: Nightly batch job computes weekly match sets; on-demand recomputation when a user requests refresh (limited frequency).
+
+### 8.4 Feedback Loop
+- Flow meter taps, conversation length, and post-date surveys feed supervised labels.
+- Federated learning roadmap: plan to move feature extraction to device where feasible; aggregate gradients with DP noise.
+- Bias audits run weekly, comparing match quality metrics across demographics.
+
+## 9. Safety & Moderation
+- **Automated Filters**: Toxicity detection on outgoing messages (Perspective API or open-source equivalent) with soft block + warning.
+- **Rate Limiting**: Prevent rapid-fire copy-paste spam; throttle for suspicious behavior.
+- **Human Review**: Internal dashboard surfaces high-severity reports; all access logged.
+- **Shadow Bans**: Repeat offenders placed into isolation pending review.
+- **Crisis Protocols**: Escalation pathway for self-harm or threat content (trained responders, external resources).
+
+## 10. UX Flow Summary
+
+1. **Welcome & Eligibility**
+   - Age check, community pledge.
+2. **Create Account**
+   - Email/phone verification.
+3. **Consent Module**
+   - Multi-step wizard explaining scopes with toggles and preview of benefits.
+4. **Profile Crafting**
+   - Long-form prompts, voice note, optional photo upload (blurred by default).
+5. **Preference Setup**
+   - Genders, distance, match frequency, conversation styles you enjoy.
+6. **Optional Social Link**
+   - Connect Twitter/X, Reddit, or Instagram; review generated summary.
+7. **Home Dashboard**
+   - Weekly matches, status indicators, upcoming refresh timer.
+8. **Match Detail**
+   - Profile preview, chemistry insights, challenge cards.
+9. **Conversation**
+   - Secure chat, flow meter, ability to bookmark key moments.
+10. **Reflection**
+   - After conversation ends or match expires, optional survey + request adjustments.
+
+## 11. Implementation Plan (Agent-Friendly)
+
+### Sprint 0: Repo & Standards
+- Initialize mono-repo with linting, formatting, tests, CI pipelines.
+- Document contribution guidelines and code of conduct.
+
+### Sprint 1: Auth, Consent, Database
+- Implement Supabase schema & RLS policies.
+- Build onboarding wizard with consent toggles and audit logging.
+
+### Sprint 2: Profile & Social Link UX
+- Long-form prompts, voice upload, optional social OAuth skeleton.
+- Consent-based scraping jobs (mock data for now).
+
+### Sprint 3: Feature Extraction Service
+- FastAPI microservice with `/extract/text` and `/extract/social` endpoints.
+- Unit tests using synthetic conversations and posts.
+
+### Sprint 4: Matching Service v1
+- Chemistry vector assembly, nearest-neighbor retrieval, reranker skeleton with fairness placeholders.
+- Nightly batch job scaffold (Celery/Temporal/Cloud scheduler).
+
+### Sprint 5: Chat & Flow Meter
+- Secure chat UI, flow meter feedback loop, challenge card library.
+- API endpoints for storing messages (encrypted) and flow signals.
+
+### Sprint 6: Safety & Moderation
+- Toxicity detection integration, block/report flows, moderation dashboard MVP.
+
+### Sprint 7: Analytics & Explainability
+- "Why this match" module with adjustable weights.
+- Bias dashboard (simple cohort comparison).
+
+### Sprint 8: Pilot Prep
+- Seed data, staging deployment, QA checklist, pilot feedback instrumentation.
+
+## 12. Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Perceived surveillance (social scraping) | Strict consent UX, editable summaries, revoke + delete pipeline. |
+| Bias in embeddings | Diverse training dataset, fairness constraints, weekly audits, human oversight. |
+| Safety incidents | Proactive toxicity detection, fast human review, shadow bans, crisis protocols. |
+| Cold start (no data) | High-signal onboarding prompts, starter challenge cards, initial heuristic matching. |
+| Overfitting to high-verbosity users | Normalize metrics by user baseline, apply tempo-aware matching. |
+
+## 13. Open Questions & Future Work
+- Expand provider list for social summaries (LinkedIn, TikTok) with ethical guidance.
+- Introduce collaborative mini-games to surface chemistry.
+- Implement full federated learning for on-device privacy.
+- Support polyamorous or non-traditional relationship structures (requires matching redesign).
+- Launch community-led Resonance Salons for acquisition and engagement.
+
+---
+
+This spec is designed to be copied into an auto-coder agent as a guiding document. Pair it with the `docs/agent-runbook.md` prompts to orchestrate implementation while maintaining the consent-first ethos central to Resonance+.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "resonance"
+version = "0.1.0"
+description = "Consent-first chemistry matching domain logic"
+authors = [{name = "Resonance Team"}]
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "-q"
+pythonpath = ["."]

--- a/resonance/__init__.py
+++ b/resonance/__init__.py
@@ -1,0 +1,5 @@
+"""Core domain logic for the Resonance+ consent-first dating prototype."""
+
+from .service import ResonanceService
+
+__all__ = ["ResonanceService"]

--- a/resonance/analytics.py
+++ b/resonance/analytics.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from statistics import mean
+from typing import Iterable, Sequence
+
+POSITIVE_WORDS = {
+    "love",
+    "like",
+    "enjoy",
+    "great",
+    "excited",
+    "curious",
+    "appreciate",
+    "thank",
+    "hope",
+    "wonder",
+}
+NEGATIVE_WORDS = {"hate", "annoyed", "angry", "sad", "upset", "worried"}
+PLAYFUL_MARKERS = {"haha", "lol", "😂", ";)", "play", "game"}
+OPENERS = {"what", "how", "why", "when", "where"}
+
+
+@dataclass(slots=True)
+class ConversationMetrics:
+    question_ratio: float
+    turn_balance: float
+    sentiment_balance: float
+    avg_response_seconds: float
+    curiosity_score: float
+    word_playfulness: float
+
+
+def _safe_mean(values: Iterable[float]) -> float:
+    data = list(values)
+    return mean(data) if data else 0.0
+
+
+def question_ratio(messages: Sequence[str]) -> float:
+    if not messages:
+        return 0.0
+    questions = sum(1 for msg in messages if "?" in msg)
+    return questions / len(messages)
+
+
+def sentiment_balance(messages: Sequence[str]) -> float:
+    if not messages:
+        return 0.0
+    counts = Counter()
+    for msg in messages:
+        lowered = msg.lower()
+        if any(word in lowered for word in POSITIVE_WORDS):
+            counts["pos"] += 1
+        if any(word in lowered for word in NEGATIVE_WORDS):
+            counts["neg"] += 1
+    total = counts["pos"] + counts["neg"]
+    if total == 0:
+        return 0.0
+    return (counts["pos"] - counts["neg"]) / total
+
+
+def curiosity_score(messages: Sequence[str]) -> float:
+    if not messages:
+        return 0.0
+    scores = 0.0
+    for msg in messages:
+        words = msg.lower().split()
+        if words and words[0] in OPENERS:
+            scores += 1.0
+        if msg.strip().endswith("?"):
+            scores += 0.5
+    return scores / len(messages)
+
+
+def word_playfulness(messages: Sequence[str]) -> float:
+    if not messages:
+        return 0.0
+    playful = sum(1 for msg in messages if any(tag in msg.lower() for tag in PLAYFUL_MARKERS))
+    return playful / len(messages)
+
+
+def turn_balance(participant_counts: Sequence[int]) -> float:
+    if not participant_counts:
+        return 0.0
+    total = sum(participant_counts)
+    if total == 0:
+        return 0.0
+    ideal = total / len(participant_counts)
+    diffs = [abs(count - ideal) / ideal if ideal else 0 for count in participant_counts]
+    return 1 - _safe_mean(diffs)
+
+
+def average_response_delta(timestamps: Sequence[datetime]) -> float:
+    if len(timestamps) < 2:
+        return 0.0
+    deltas = [
+        (t2 - t1).total_seconds()
+        for t1, t2 in zip(timestamps[:-1], timestamps[1:])
+        if t2 > t1
+    ]
+    return _safe_mean(deltas)
+
+
+def compute_metrics(
+    user_messages: Sequence[str],
+    partner_messages: Sequence[str],
+    timestamps: Sequence[datetime],
+) -> ConversationMetrics:
+    return ConversationMetrics(
+        question_ratio=question_ratio(user_messages),
+        turn_balance=turn_balance([len(user_messages), len(partner_messages)]),
+        sentiment_balance=sentiment_balance(user_messages),
+        avg_response_seconds=average_response_delta(timestamps),
+        curiosity_score=curiosity_score(user_messages),
+        word_playfulness=word_playfulness(user_messages),
+    )

--- a/resonance/api.py
+++ b/resonance/api.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from http import HTTPStatus
+from typing import Any, Dict, Iterable, Optional
+from urllib.parse import parse_qs, urlparse
+
+from .models import ChemistryProfile, ConsentDecision, ConsentScope, MatchCandidate, MatchFeedback, User
+from .service import ConversationMessage, ResonanceService
+from .storage import Storage
+
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+@dataclass(slots=True)
+class Response:
+    status: int
+    body: Any
+    headers: Dict[str, str] = field(default_factory=lambda: {"Content-Type": "application/json"})
+
+
+class ResonanceAPI:
+    """Minimal HTTP-style interface for the Resonance+ domain service."""
+
+    def __init__(self, service: ResonanceService | None = None) -> None:
+        self.service = service or ResonanceService()
+
+    # -- public dispatch -------------------------------------------------
+    def handle(
+        self,
+        method: str,
+        path: str,
+        body: Optional[dict[str, Any]] = None,
+        query: Optional[dict[str, str]] = None,
+    ) -> Response:
+        body = body or {}
+        query = query or {}
+        parts = [segment for segment in path.strip("/").split("/") if segment]
+
+        try:
+            if method == "POST" and parts == ["users"]:
+                return self._register_user(body)
+            if method == "GET" and len(parts) == 2 and parts[0] == "users":
+                return self._get_user(int(parts[1]))
+            if len(parts) == 3 and parts[0] == "users" and parts[2] == "consents":
+                user_id = int(parts[1])
+                if method == "GET":
+                    return self._get_consents(user_id)
+                if method == "PATCH":
+                    return self._update_consents(user_id, body)
+            if len(parts) == 3 and parts[0] == "users" and parts[2] == "conversations" and method == "POST":
+                return self._ingest_conversation(int(parts[1]), body)
+            if len(parts) == 3 and parts[0] == "users" and parts[2] == "matches" and method == "GET":
+                limit = int(query.get("limit", "3"))
+                return self._suggest_matches(int(parts[1]), limit)
+            if parts == ["feedback"] and method == "POST":
+                return self._submit_feedback(body)
+            if len(parts) == 3 and parts[0] == "users" and parts[2] == "feedback" and method == "GET":
+                return self._list_feedback(int(parts[1]))
+        except PermissionError as exc:
+            return Response(status=HTTPStatus.FORBIDDEN, body={"detail": str(exc)})
+        except ValueError as exc:
+            return Response(status=HTTPStatus.BAD_REQUEST, body={"detail": str(exc)})
+
+        return Response(status=HTTPStatus.NOT_FOUND, body={"detail": "endpoint not found"})
+
+    # -- endpoint implementations ---------------------------------------
+    def _register_user(self, data: dict[str, Any]) -> Response:
+        email = data.get("email")
+        display_name = data.get("display_name")
+        if not isinstance(email, str) or not email:
+            raise ValueError("email is required")
+        consent_flags: dict[ConsentScope, bool] = {}
+        for item in data.get("consents", []):
+            if not isinstance(item, dict):
+                raise ValueError("invalid consent payload")
+            try:
+                scope = ConsentScope(item["scope"])
+            except (KeyError, ValueError) as exc:
+                raise ValueError("invalid consent scope") from exc
+            consent_flags[scope] = bool(item.get("granted"))
+        user = self.service.register_user(email, display_name, consent_flags=consent_flags)
+        return Response(status=HTTPStatus.CREATED, body=_serialise_user(user))
+
+    def _get_user(self, user_id: int) -> Response:
+        user = self.service.get_user(user_id)
+        return Response(status=HTTPStatus.OK, body=_serialise_user(user))
+
+    def _get_consents(self, user_id: int) -> Response:
+        consents = self.service.get_consents(user_id)
+        payload = [_serialise_consent(consent) for consent in _order_consents(consents.values())]
+        return Response(status=HTTPStatus.OK, body=payload)
+
+    def _update_consents(self, user_id: int, data: dict[str, Any]) -> Response:
+        if not isinstance(data, list):
+            raise ValueError("expected list of consent updates")
+        updates = {}
+        for item in data:
+            if not isinstance(item, dict):
+                raise ValueError("invalid consent payload")
+            try:
+                scope = ConsentScope(item["scope"])
+            except (KeyError, ValueError) as exc:
+                raise ValueError("invalid consent scope") from exc
+            updates[scope] = bool(item.get("granted"))
+        consents = self.service.update_consents(user_id, updates)
+        payload = [_serialise_consent(consent) for consent in _order_consents(consents.values())]
+        return Response(status=HTTPStatus.OK, body=payload)
+
+    def _ingest_conversation(self, user_id: int, data: dict[str, Any]) -> Response:
+        messages_payload = data.get("messages")
+        if not isinstance(messages_payload, list):
+            raise ValueError("messages must be a list")
+        parsed_messages = []
+        for item in messages_payload:
+            if not isinstance(item, dict):
+                raise ValueError("invalid message payload")
+            parsed_messages.append(
+                ConversationMessage(
+                    author=item.get("author"),
+                    text=item.get("text", ""),
+                    timestamp=_parse_timestamp(item.get("timestamp")),
+                )
+            )
+        profile = self.service.ingest_conversation(user_id, parsed_messages)
+        return Response(status=HTTPStatus.OK, body=_serialise_profile(profile))
+
+    def _suggest_matches(self, user_id: int, limit: int) -> Response:
+        matches = self.service.suggest_matches(user_id, limit=limit)
+        return Response(status=HTTPStatus.OK, body=[_serialise_match(candidate) for candidate in matches])
+
+    def _submit_feedback(self, data: dict[str, Any]) -> Response:
+        try:
+            user_id = int(data.get("user_id"))
+            partner_id = int(data.get("partner_id"))
+            flow_rating = int(data.get("flow_rating"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("invalid feedback payload") from exc
+        feedback = self.service.submit_feedback(user_id, partner_id, flow_rating)
+        return Response(status=HTTPStatus.CREATED, body=_serialise_feedback(feedback))
+
+    def _list_feedback(self, user_id: int) -> Response:
+        feedback = self.service.list_feedback(user_id)
+        return Response(status=HTTPStatus.OK, body=[_serialise_feedback(item) for item in feedback])
+
+
+# -- serialisation helpers -----------------------------------------------
+
+
+def _serialise_user(user: User) -> dict[str, Any]:
+    return {
+        "id": user.id,
+        "email": user.email,
+        "display_name": user.display_name,
+        "created_at": _iso(user.created_at),
+    }
+
+
+def _serialise_consent(consent: ConsentDecision) -> dict[str, Any]:
+    return {
+        "scope": consent.scope.value,
+        "granted": consent.granted,
+        "updated_at": _iso(consent.updated_at),
+    }
+
+
+def _serialise_profile(profile: ChemistryProfile) -> dict[str, Any]:
+    payload = asdict(profile)
+    payload["updated_at"] = _iso(profile.updated_at)
+    return payload
+
+
+def _serialise_match(candidate: MatchCandidate) -> dict[str, Any]:
+    return {
+        "user_id": candidate.user_id,
+        "score": candidate.score,
+        "alignment": candidate.alignment,
+    }
+
+
+def _serialise_feedback(feedback: MatchFeedback) -> dict[str, Any]:
+    return {
+        "id": feedback.id,
+        "user_id": feedback.user_id,
+        "partner_id": feedback.partner_id,
+        "flow_rating": feedback.flow_rating,
+        "created_at": _iso(feedback.created_at),
+    }
+
+
+def _order_consents(consents: Iterable[ConsentDecision]) -> list[ConsentDecision]:
+    return sorted(consents, key=lambda decision: decision.scope.value)
+
+
+def _iso(value: datetime) -> str:
+    return value.strftime(ISO_FORMAT)
+
+
+def _parse_timestamp(raw: Any) -> datetime:
+    if isinstance(raw, datetime):
+        return raw
+    if isinstance(raw, str):
+        try:
+            if raw.endswith("Z"):
+                return datetime.strptime(raw, ISO_FORMAT)
+            return datetime.fromisoformat(raw)
+        except ValueError as exc:  # pragma: no cover - protective branch
+            raise ValueError("invalid timestamp format") from exc
+    raise ValueError("timestamp required")
+
+
+# -- simple HTTP server ---------------------------------------------------
+
+
+class _HTTPHandler:
+    def __init__(self, api: ResonanceAPI) -> None:
+        self.api = api
+
+    def __call__(self, environ, start_response):  # type: ignore[override]
+        method = environ["REQUEST_METHOD"].upper()
+        parsed = urlparse(environ["PATH_INFO"] + ("?" + environ["QUERY_STRING"] if environ["QUERY_STRING"] else ""))
+        length = int(environ.get("CONTENT_LENGTH") or 0)
+        body_bytes = environ["wsgi.input"].read(length) if length else b""
+        body = json.loads(body_bytes.decode("utf-8") or "null") if body_bytes else None
+        query = {key: values[-1] for key, values in parse_qs(parsed.query).items()}
+
+        response = self.api.handle(method, parsed.path, body=body, query=query)
+        start_response(f"{response.status} {HTTPStatus(response.status).phrase}", list(response.headers.items()))
+        payload = json.dumps(response.body).encode("utf-8") if response.body is not None else b""
+        return [payload]
+
+
+def run(host: str = "127.0.0.1", port: int = 8000) -> None:
+    from wsgiref.simple_server import make_server
+
+    api = ResonanceAPI()
+    handler = _HTTPHandler(api)
+    with make_server(host, port, handler) as httpd:  # pragma: no cover - manual use only
+        print(f"Serving Resonance+ API on http://{host}:{port}")
+        httpd.serve_forever()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the Resonance+ HTTP API")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--database", default="resonance.db")
+    args = parser.parse_args()
+
+    api = ResonanceAPI(ResonanceService(Storage(args.database)))
+    handler = _HTTPHandler(api)
+
+    from wsgiref.simple_server import make_server
+
+    with make_server(args.host, args.port, handler) as httpd:  # pragma: no cover - manual use only
+        print(f"Serving Resonance+ API on http://{args.host}:{args.port}")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/resonance/models.py
+++ b/resonance/models.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Dict, Optional
+
+
+class ConsentScope(str, Enum):
+    """Scopes of consent supported by the system."""
+
+    IN_APP_ANALYSIS = "in_app_analysis"
+    SOCIAL_SCRAPE = "social_scrape"
+    VOICE_ANALYSIS = "voice_analysis"
+
+
+@dataclass(slots=True)
+class User:
+    id: int
+    email: str
+    display_name: Optional[str]
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass(slots=True)
+class ConsentDecision:
+    user_id: int
+    scope: ConsentScope
+    granted: bool
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass(slots=True)
+class ChemistryProfile:
+    user_id: int
+    question_ratio: float
+    turn_balance: float
+    sentiment_balance: float
+    avg_response_seconds: float
+    curiosity_score: float
+    word_playfulness: float
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+
+    def as_vector(self) -> Dict[str, float]:
+        return {
+            "question_ratio": self.question_ratio,
+            "turn_balance": self.turn_balance,
+            "sentiment_balance": self.sentiment_balance,
+            "avg_response_seconds": self.avg_response_seconds,
+            "curiosity_score": self.curiosity_score,
+            "word_playfulness": self.word_playfulness,
+        }
+
+
+@dataclass(slots=True)
+class MatchCandidate:
+    user_id: int
+    score: float
+    alignment: Dict[str, float]
+
+
+@dataclass(slots=True)
+class MatchFeedback:
+    id: int
+    user_id: int
+    partner_id: int
+    flow_rating: int
+    created_at: datetime = field(default_factory=datetime.utcnow)

--- a/resonance/service.py
+++ b/resonance/service.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from math import sqrt
+from typing import List, Sequence
+
+from .analytics import compute_metrics
+from .models import (
+    ChemistryProfile,
+    ConsentDecision,
+    ConsentScope,
+    MatchCandidate,
+    MatchFeedback,
+    User,
+)
+from .storage import Storage
+
+
+@dataclass(slots=True)
+class ConversationMessage:
+    """Message submitted for conversational analysis."""
+
+    author: str
+    text: str
+    timestamp: datetime
+
+    def __post_init__(self) -> None:
+        if self.author not in {"self", "partner"}:
+            raise ValueError("author must be 'self' or 'partner'")
+        if not self.text.strip():
+            raise ValueError("message text cannot be empty")
+
+
+class ResonanceService:
+    """High-level orchestration of consent, analytics, and matching."""
+
+    def __init__(self, storage: Storage | None = None) -> None:
+        self.storage = storage or Storage(":memory:")
+
+    # -- user onboarding -------------------------------------------------
+    def register_user(
+        self,
+        email: str,
+        display_name: str | None,
+        *,
+        consent_flags: dict[ConsentScope, bool] | None = None,
+    ) -> User:
+        try:
+            user = self.storage.add_user(email=email, display_name=display_name)
+        except Exception as exc:  # pragma: no cover - sqlite raises sqlite3.IntegrityError
+            raise ValueError("email already registered") from exc
+        flags = consent_flags or {}
+        for scope in ConsentScope:
+            granted = bool(flags.get(scope, False))
+            self.storage.set_consent(user.id, scope, granted)
+        return user
+
+    def get_user(self, user_id: int) -> User:
+        user = self.storage.get_user(user_id)
+        if not user:
+            raise ValueError("user not found")
+        return user
+
+    def get_consents(self, user_id: int) -> dict[ConsentScope, ConsentDecision]:
+        if not self.storage.get_user(user_id):
+            raise ValueError("user not found")
+        consents = self.storage.get_consents(user_id)
+        for scope in ConsentScope:
+            consents.setdefault(
+                scope,
+                ConsentDecision(user_id=user_id, scope=scope, granted=False),
+            )
+        return consents
+
+    def update_consents(self, user_id: int, flags: dict[ConsentScope, bool]) -> dict[ConsentScope, ConsentDecision]:
+        if not self.storage.get_user(user_id):
+            raise ValueError("user not found")
+        for scope, granted in flags.items():
+            self.storage.set_consent(user_id, scope, bool(granted))
+        return self.get_consents(user_id)
+
+    # -- conversation analysis ------------------------------------------
+    def ingest_conversation(
+        self, user_id: int, messages: Sequence[ConversationMessage]
+    ) -> ChemistryProfile:
+        if not messages:
+            raise ValueError("no messages provided")
+        if not self.storage.get_user(user_id):
+            raise ValueError("user not found")
+        consents = self.get_consents(user_id)
+        if not consents[ConsentScope.IN_APP_ANALYSIS].granted:
+            raise PermissionError("in-app analysis consent required")
+
+        ordered = sorted(messages, key=lambda msg: msg.timestamp)
+        user_messages = [msg.text for msg in ordered if msg.author == "self"]
+        partner_messages = [msg.text for msg in ordered if msg.author == "partner"]
+        timestamps = [msg.timestamp for msg in ordered]
+
+        metrics = compute_metrics(user_messages, partner_messages, timestamps)
+        profile = ChemistryProfile(
+            user_id=user_id,
+            question_ratio=metrics.question_ratio,
+            turn_balance=metrics.turn_balance,
+            sentiment_balance=metrics.sentiment_balance,
+            avg_response_seconds=metrics.avg_response_seconds,
+            curiosity_score=metrics.curiosity_score,
+            word_playfulness=metrics.word_playfulness,
+            updated_at=datetime.utcnow(),
+        )
+        return self.storage.upsert_profile(profile)
+
+    # -- matching --------------------------------------------------------
+    def suggest_matches(self, user_id: int, limit: int = 3) -> List[MatchCandidate]:
+        profile = self.storage.get_profile(user_id)
+        if not profile:
+            raise ValueError("no chemistry profile for user")
+        user_vector = list(profile.as_vector().values())
+        candidates: List[MatchCandidate] = []
+        for other_profile in self.storage.iter_profiles(exclude_user=user_id):
+            other_vector = list(other_profile.as_vector().values())
+            score = self._score(user_vector, other_vector)
+            alignment = self._alignment(profile, other_profile)
+            candidates.append(MatchCandidate(user_id=other_profile.user_id, score=score, alignment=alignment))
+        candidates.sort(key=lambda c: c.score, reverse=True)
+        return candidates[: max(limit, 0)]
+
+    def _score(self, left: Sequence[float], right: Sequence[float]) -> float:
+        distance = sqrt(sum((a - b) ** 2 for a, b in zip(left, right)))
+        return round(1 / (1 + distance), 4)
+
+    def _alignment(self, base: ChemistryProfile, other: ChemistryProfile) -> dict[str, float]:
+        alignment: dict[str, float] = {}
+        for key in base.as_vector():
+            base_value = base.as_vector()[key]
+            other_value = other.as_vector()[key]
+            alignment[key] = round(max(0.0, 1 - abs(base_value - other_value)), 3)
+        return alignment
+
+    # -- feedback --------------------------------------------------------
+    def submit_feedback(self, user_id: int, partner_id: int, flow_rating: int) -> MatchFeedback:
+        if user_id == partner_id:
+            raise ValueError("cannot submit feedback for self")
+        if not 1 <= flow_rating <= 5:
+            raise ValueError("flow rating must be between 1 and 5")
+        if not self.storage.get_user(user_id) or not self.storage.get_user(partner_id):
+            raise ValueError("user not found")
+        return self.storage.add_feedback(user_id, partner_id, flow_rating)
+
+    def list_feedback(self, user_id: int) -> List[MatchFeedback]:
+        if not self.storage.get_user(user_id):
+            raise ValueError("user not found")
+        return self.storage.list_feedback(user_id)

--- a/resonance/storage.py
+++ b/resonance/storage.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional
+
+from .models import (
+    ChemistryProfile,
+    ConsentDecision,
+    ConsentScope,
+    MatchFeedback,
+    User,
+)
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
+
+
+class Storage:
+    """SQLite-backed persistence for the Resonance+ prototype."""
+
+    def __init__(self, path: str | Path = "resonance.db") -> None:
+        self.path = str(path)
+        self._connection = sqlite3.connect(self.path, detect_types=sqlite3.PARSE_DECLTYPES)
+        self._connection.row_factory = sqlite3.Row
+        self.initialise()
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        return self._connection
+
+    def initialise(self) -> None:
+        with closing(self.connection.cursor()) as cursor:
+            cursor.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS users (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    email TEXT UNIQUE NOT NULL,
+                    display_name TEXT,
+                    created_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS consents (
+                    user_id INTEGER NOT NULL,
+                    scope TEXT NOT NULL,
+                    granted INTEGER NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (user_id, scope),
+                    FOREIGN KEY (user_id) REFERENCES users(id)
+                );
+
+                CREATE TABLE IF NOT EXISTS chemistry_profiles (
+                    user_id INTEGER PRIMARY KEY,
+                    question_ratio REAL NOT NULL,
+                    turn_balance REAL NOT NULL,
+                    sentiment_balance REAL NOT NULL,
+                    avg_response_seconds REAL NOT NULL,
+                    curiosity_score REAL NOT NULL,
+                    word_playfulness REAL NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    FOREIGN KEY (user_id) REFERENCES users(id)
+                );
+
+                CREATE TABLE IF NOT EXISTS match_feedback (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    partner_id INTEGER NOT NULL,
+                    flow_rating INTEGER NOT NULL,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (user_id) REFERENCES users(id)
+                );
+                """
+            )
+            self.connection.commit()
+
+    def close(self) -> None:
+        self.connection.close()
+
+    # -- user operations -------------------------------------------------
+    def add_user(self, email: str, display_name: Optional[str]) -> User:
+        timestamp = datetime.utcnow().strftime(ISO_FORMAT)
+        with closing(self.connection.cursor()) as cursor:
+            cursor.execute(
+                "INSERT INTO users (email, display_name, created_at) VALUES (?, ?, ?)",
+                (email, display_name, timestamp),
+            )
+            user_id = cursor.lastrowid
+        self.connection.commit()
+        return User(id=user_id, email=email, display_name=display_name, created_at=datetime.strptime(timestamp, ISO_FORMAT))
+
+    def get_user(self, user_id: int) -> Optional[User]:
+        with closing(self.connection.cursor()) as cursor:
+            cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+            row = cursor.fetchone()
+        if not row:
+            return None
+        return User(
+            id=row["id"],
+            email=row["email"],
+            display_name=row["display_name"],
+            created_at=datetime.strptime(row["created_at"], ISO_FORMAT),
+        )
+
+    # -- consent operations ---------------------------------------------
+    def set_consent(self, user_id: int, scope: ConsentScope, granted: bool) -> ConsentDecision:
+        timestamp = datetime.utcnow().strftime(ISO_FORMAT)
+        with closing(self.connection.cursor()) as cursor:
+            cursor.execute(
+                """
+                INSERT INTO consents (user_id, scope, granted, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(user_id, scope)
+                DO UPDATE SET granted = excluded.granted, updated_at = excluded.updated_at
+                """,
+                (user_id, scope.value, int(granted), timestamp),
+            )
+        self.connection.commit()
+        return ConsentDecision(
+            user_id=user_id,
+            scope=scope,
+            granted=granted,
+            updated_at=datetime.strptime(timestamp, ISO_FORMAT),
+        )
+
+    def get_consents(self, user_id: int) -> Dict[ConsentScope, ConsentDecision]:
+        with closing(self.connection.cursor()) as cursor:
+            cursor.execute("SELECT * FROM consents WHERE user_id = ?", (user_id,))
+            rows = cursor.fetchall()
+        return {
+            ConsentScope(row["scope"]): ConsentDecision(
+                user_id=user_id,
+                scope=ConsentScope(row["scope"]),
+                granted=bool(row["granted"]),
+                updated_at=datetime.strptime(row["updated_at"], ISO_FORMAT),
+            )
+            for row in rows
+        }
+
+    # -- chemistry profiles ---------------------------------------------
+    def upsert_profile(self, profile: ChemistryProfile) -> ChemistryProfile:
+        timestamp = profile.updated_at.strftime(ISO_FORMAT)
+        with closing(self.connection.cursor()) as cursor:
+            cursor.execute(
+                """
+                INSERT INTO chemistry_profiles (
+                    user_id, question_ratio, turn_balance, sentiment_balance,
+                    avg_response_seconds, curiosity_score, word_playfulness, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(user_id) DO UPDATE SET
+                    question_ratio = excluded.question_ratio,
+                    turn_balance = excluded.turn_balance,
+                    sentiment_balance = excluded.sentiment_balance,
+                    avg_response_seconds = excluded.avg_response_seconds,
+                    curiosity_score = excluded.curiosity_score,
+                    word_playfulness = excluded.word_playfulness,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    profile.user_id,
+                    profile.question_ratio,
+                    profile.turn_balance,
+                    profile.sentiment_balance,
+                    profile.avg_response_seconds,
+                    profile.curiosity_score,
+                    profile.word_playfulness,
+                    timestamp,
+                ),
+            )
+        self.connection.commit()
+        return profile
+
+    def get_profile(self, user_id: int) -> Optional[ChemistryProfile]:
+        with closing(self.connection.cursor()) as cursor:
+            cursor.execute("SELECT * FROM chemistry_profiles WHERE user_id = ?", (user_id,))
+            row = cursor.fetchone()
+        if not row:
+            return None
+        return ChemistryProfile(
+            user_id=row["user_id"],
+            question_ratio=row["question_ratio"],
+            turn_balance=row["turn_balance"],
+            sentiment_balance=row["sentiment_balance"],
+            avg_response_seconds=row["avg_response_seconds"],
+            curiosity_score=row["curiosity_score"],
+            word_playfulness=row["word_playfulness"],
+            updated_at=datetime.strptime(row["updated_at"], ISO_FORMAT),
+        )
+
+    def iter_profiles(self, exclude_user: int | None = None) -> Iterator[ChemistryProfile]:
+        query = "SELECT * FROM chemistry_profiles"
+        params: List[object] = []
+        if exclude_user is not None:
+            query += " WHERE user_id != ?"
+            params.append(exclude_user)
+        with closing(self.connection.cursor()) as cursor:
+            cursor.execute(query, params)
+            rows = cursor.fetchall()
+        for row in rows:
+            yield ChemistryProfile(
+                user_id=row["user_id"],
+                question_ratio=row["question_ratio"],
+                turn_balance=row["turn_balance"],
+                sentiment_balance=row["sentiment_balance"],
+                avg_response_seconds=row["avg_response_seconds"],
+                curiosity_score=row["curiosity_score"],
+                word_playfulness=row["word_playfulness"],
+                updated_at=datetime.strptime(row["updated_at"], ISO_FORMAT),
+            )
+
+    def reset(self) -> None:
+        with closing(self.connection.cursor()) as cursor:
+            cursor.executescript(
+                """
+                DELETE FROM match_feedback;
+                DELETE FROM chemistry_profiles;
+                DELETE FROM consents;
+                DELETE FROM users;
+                """
+            )
+        self.connection.commit()
+
+    # -- feedback -------------------------------------------------------
+    def add_feedback(self, user_id: int, partner_id: int, flow_rating: int) -> MatchFeedback:
+        timestamp = datetime.utcnow().strftime(ISO_FORMAT)
+        with closing(self.connection.cursor()) as cursor:
+            cursor.execute(
+                """
+                INSERT INTO match_feedback (user_id, partner_id, flow_rating, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (user_id, partner_id, flow_rating, timestamp),
+            )
+            feedback_id = cursor.lastrowid
+        self.connection.commit()
+        return MatchFeedback(
+            id=feedback_id,
+            user_id=user_id,
+            partner_id=partner_id,
+            flow_rating=flow_rating,
+            created_at=datetime.strptime(timestamp, ISO_FORMAT),
+        )
+
+    def list_feedback(self, user_id: int) -> List[MatchFeedback]:
+        with closing(self.connection.cursor()) as cursor:
+            cursor.execute(
+                "SELECT * FROM match_feedback WHERE user_id = ? ORDER BY created_at DESC",
+                (user_id,),
+            )
+            rows = cursor.fetchall()
+        return [
+            MatchFeedback(
+                id=row["id"],
+                user_id=row["user_id"],
+                partner_id=row["partner_id"],
+                flow_rating=row["flow_rating"],
+                created_at=datetime.strptime(row["created_at"], ISO_FORMAT),
+            )
+            for row in rows
+        ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from resonance.api import ResonanceAPI
+from resonance.service import ResonanceService
+from resonance.storage import Storage
+
+
+@pytest.fixture()
+def api() -> ResonanceAPI:
+    storage = Storage(":memory:")
+    service = ResonanceService(storage)
+    api_instance = ResonanceAPI(service)
+    yield api_instance
+    storage.close()
+
+
+def _post(api: ResonanceAPI, path: str, body: dict) -> dict:
+    response = api.handle("POST", path, body=body)
+    assert response.status in {200, 201}, response.body
+    return response.body
+
+
+def _get(api: ResonanceAPI, path: str, *, query: dict | None = None) -> dict | list:
+    response = api.handle("GET", path, query=query)
+    assert response.status == 200, response.body
+    return response.body
+
+
+def test_full_matching_flow(api: ResonanceAPI) -> None:
+    first = _post(
+        api,
+        "/users",
+        {
+            "email": "one@example.com",
+            "display_name": "One",
+            "consents": [{"scope": "in_app_analysis", "granted": True}],
+        },
+    )
+    second = _post(
+        api,
+        "/users",
+        {
+            "email": "two@example.com",
+            "display_name": "Two",
+            "consents": [{"scope": "in_app_analysis", "granted": True}],
+        },
+    )
+
+    base_time = datetime.utcnow()
+    conversation = {
+        "messages": [
+            {
+                "author": "self",
+                "text": "What futures excite you?",
+                "timestamp": base_time.isoformat(),
+            },
+            {
+                "author": "partner",
+                "text": "Ones we build together.",
+                "timestamp": (base_time + timedelta(seconds=5)).isoformat(),
+            },
+        ]
+    }
+    _post(api, f"/users/{first['id']}/conversations", conversation)
+
+    mirror = {
+        "messages": [
+            {
+                "author": "self",
+                "text": "Shared futures are powerful.",
+                "timestamp": base_time.isoformat(),
+            },
+            {
+                "author": "partner",
+                "text": "Absolutely—alignment matters.",
+                "timestamp": (base_time + timedelta(seconds=7)).isoformat(),
+            },
+        ]
+    }
+    _post(api, f"/users/{second['id']}/conversations", mirror)
+
+    matches = _get(api, f"/users/{first['id']}/matches")
+    assert isinstance(matches, list)
+    assert matches and matches[0]["user_id"] == second["id"]
+    assert 0 < matches[0]["score"] <= 1
+
+    feedback_payload = {
+        "user_id": first["id"],
+        "partner_id": second["id"],
+        "flow_rating": 4,
+    }
+    _post(api, "/feedback", feedback_payload)
+
+    feedback = _get(api, f"/users/{first['id']}/feedback")
+    assert isinstance(feedback, list)
+    assert feedback[0]["flow_rating"] == 4
+
+
+def test_conversation_requires_consent(api: ResonanceAPI) -> None:
+    user = _post(api, "/users", {"email": "no@example.com", "display_name": None, "consents": []})
+    response = api.handle(
+        "POST",
+        f"/users/{user['id']}/conversations",
+        body={
+            "messages": [
+                {
+                    "author": "self",
+                    "text": "Hello",
+                    "timestamp": datetime.utcnow().isoformat(),
+                }
+            ]
+        },
+    )
+    assert response.status == 403
+    assert "consent" in response.body["detail"].lower()
+
+
+def test_update_consents_round_trip(api: ResonanceAPI) -> None:
+    user = _post(api, "/users", {"email": "scope@example.com", "display_name": "Scope", "consents": []})
+    update_response = api.handle(
+        "PATCH",
+        f"/users/{user['id']}/consents",
+        body=[{"scope": "in_app_analysis", "granted": True}],
+    )
+    assert update_response.status == 200
+    consents = {entry["scope"]: entry["granted"] for entry in update_response.body}
+    assert consents["in_app_analysis"] is True

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from resonance.models import ConsentScope
+from resonance.service import ConversationMessage, ResonanceService
+from resonance.storage import Storage
+
+
+@pytest.fixture()
+def service(tmp_path):
+    db_path = tmp_path / "resonance.db"
+    storage = Storage(db_path)
+    svc = ResonanceService(storage)
+    yield svc
+    storage.close()
+
+
+def create_sample_conversation(start: datetime, delta: float) -> list[ConversationMessage]:
+    return [
+        ConversationMessage(author="self", text="What lights you up?", timestamp=start),
+        ConversationMessage(
+            author="partner",
+            text="I love designing playful futures!",
+            timestamp=start + timedelta(seconds=delta),
+        ),
+        ConversationMessage(
+            author="self",
+            text="Haha same, I appreciate curious minds.",
+            timestamp=start + timedelta(seconds=delta * 2),
+        ),
+    ]
+
+
+def test_end_to_end_matching(service: ResonanceService):
+    user_a = service.register_user(
+        "a@example.com",
+        "Alice",
+        consent_flags={ConsentScope.IN_APP_ANALYSIS: True},
+    )
+    user_b = service.register_user(
+        "b@example.com",
+        "Bob",
+        consent_flags={ConsentScope.IN_APP_ANALYSIS: True},
+    )
+    user_c = service.register_user(
+        "c@example.com",
+        "Charlie",
+        consent_flags={ConsentScope.IN_APP_ANALYSIS: True},
+    )
+
+    now = datetime.utcnow()
+    service.ingest_conversation(user_a.id, create_sample_conversation(now, 4))
+    service.ingest_conversation(user_b.id, create_sample_conversation(now + timedelta(seconds=30), 5))
+    service.ingest_conversation(user_c.id, create_sample_conversation(now + timedelta(seconds=60), 15))
+
+    matches = service.suggest_matches(user_a.id, limit=2)
+    assert len(matches) == 2
+    assert matches[0].user_id in {user_b.id, user_c.id}
+    assert matches[0].score >= matches[1].score
+
+
+def test_consent_required(service: ResonanceService):
+    user = service.register_user(
+        "d@example.com",
+        "Dana",
+        consent_flags={ConsentScope.IN_APP_ANALYSIS: False},
+    )
+    with pytest.raises(PermissionError):
+        service.ingest_conversation(
+            user.id,
+            [
+                ConversationMessage(
+                    author="self",
+                    text="hello?",
+                    timestamp=datetime.utcnow(),
+                )
+            ],
+        )
+
+
+def test_feedback_cycle(service: ResonanceService):
+    user_a = service.register_user(
+        "alpha@example.com",
+        "Alpha",
+        consent_flags={ConsentScope.IN_APP_ANALYSIS: True},
+    )
+    user_b = service.register_user(
+        "beta@example.com",
+        "Beta",
+        consent_flags={ConsentScope.IN_APP_ANALYSIS: True},
+    )
+    feedback = service.submit_feedback(user_a.id, user_b.id, flow_rating=4)
+    assert feedback.flow_rating == 4
+    history = service.list_feedback(user_a.id)
+    assert len(history) == 1
+    assert history[0].partner_id == user_b.id


### PR DESCRIPTION
## Summary
- implement a standard-library HTTP API facade that handles onboarding, consents, conversation ingestion, match suggestions, and feedback while exposing a minimal WSGI server entrypoint
- add integration-style tests that exercise registration, conversation ingestion, matching, feedback, and consent enforcement through the API dispatch layer
- document how to launch the lightweight HTTP server from the command line for manual exploration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca2bfddc408331b86e282561a62289